### PR TITLE
Add support for Dropwizard 0.9. Most of the authentication changes re…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.dropwizard-bundles</groupId>
   <artifactId>dropwizard-api-key-bundle</artifactId>
-  <version>0.8.5-1-SNAPSHOT</version>  <!-- Make sure to keep this in sync with the dropwizard version below. -->
+  <version>0.9.1-1-SNAPSHOT</version>  <!-- Make sure to keep this in sync with the dropwizard version below. -->
   <packaging>jar</packaging>
 
   <name>dropwizard-api-key-bundle</name>
@@ -48,10 +48,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <dropwizard.version>0.8.5</dropwizard.version>
-    <jersey.version>2.21</jersey.version>
+    <dropwizard.version>0.9.1</dropwizard.version>
+    <jersey.version>2.22.1</jersey.version>
     <junit.version>4.12</junit.version>
-    <mockito.version>1.10.17</mockito.version>
+    <mockito.version>1.10.19</mockito.version>
   </properties>
 
   <build>

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,10 @@
 # dropwizard-api-key-bundle
 
 A [Dropwizard][dropwizard] bundle that provides a simple way to manage API keys for callers of
-your service.
+your service. The bundle provides support for authentication only; authorization is supported
+by optionally providing an `Authorizer` as documented below.
 
-[![Build Status](https://secure.travis-ci.org/dropwizard-bundles/dropwizard-api-key-bundle.png?branch=master)]
+[![Build Status](https://secure.travis-ci.org/dropwizard-bundles/dropwizard-api-key-bundle.png?branch=dropwizard-0.9)]
 (http://travis-ci.org/dropwizard-bundles/dropwizard-api-key-bundle)
 
 
@@ -15,17 +16,46 @@ Just add this maven dependency to get started:
 <dependency>
   <groupId>io.dropwizard-bundles</groupId>
   <artifactId>dropwizard-api-key-bundle</artifactId>
-  <version>0.8.4-1</version>
+  <version>0.9.1-1-SNAPSHOT</version>
 </dependency>
 ```
 
-Add the bundle to your environment:
+If you only need authentication and a default `Principal` implementation add the default
+version of the bundle to your environment:
 
 ```java
 public class MyApplication extends Application<MyConfiguration> {
   @Override
   public void initialize(Bootstrap<MyConfiguration> bootstrap) {
-    bootstrap.addBundle(new ApiKeyBundle<>());
+    bootstrap.addBundle(new DefaultApiKeyBundle<>());
+  }
+
+  @Override
+  public void run(MyConfiguration cfg, Environment env) throws Exception {
+    // ...
+  }
+}
+```
+
+If you need to provide an `Authorizer` or a different `Principal` (extending type), or both,
+add the bundle to your environment and provide the type extending the `Principal` interface, an
+implementation of the `Authorizer` and `PrincipalFactory` as appropriate:
+
+```java
+public class MyApplication extends Application<MyConfiguration> {
+  @Override
+  public void initialize(Bootstrap<MyConfiguration> bootstrap) {
+    bootstrap.addBundle(new ApiKeyBundle<>(User.class, new PrincipalFactory<User>() {
+      @Override
+      public User create(String name) {
+        // Do something interesting...
+        return new User(name);
+      }}, new Authorizer<User>() {
+        @Override
+        public boolean authorize(User user, String role) {
+          return user.getName().equals("application-1") && role.equals("ADMIN");
+        }
+    });
   }
 
   @Override
@@ -55,9 +85,9 @@ public class MyConfiguration implements ApiKeyBundleConfiguration {
 ```
 
 Now you can use API key based authentication in your application by declaring a method on a resource
-that has an `@Auth` annotated `String` parameter.  See the
-[Dropwizard Authentication][authentication] documentation for more details.  The passed in parameter
-value will be the name of the application that made the request if the authentication process was
+that has an `@Auth` annotated `Principal` parameter (or an extending type).  See the
+[Dropwizard Authentication][authentication] documentation for more details.  The name of the `Principal`
+will be the name of the application that made the request if the authentication process was
 successful.
 
 As far as configuration goes you can define your API keys in your application's config file.
@@ -75,4 +105,4 @@ authentication:
 ```
 
 [dropwizard]: http://dropwizard.io
-[authentication]: http://www.dropwizard.io/0.8.5/docs/manual/auth.html
+[authentication]: http://www.dropwizard.io/0.9.1/docs/manual/auth.html

--- a/src/main/java/io/dropwizard/bundles/apikey/ApiKeyBundle.java
+++ b/src/main/java/io/dropwizard/bundles/apikey/ApiKeyBundle.java
@@ -4,23 +4,48 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import com.google.common.cache.CacheBuilderSpec;
 import io.dropwizard.ConfiguredBundle;
-import io.dropwizard.auth.AuthFactory;
+import io.dropwizard.auth.AuthDynamicFeature;
+import io.dropwizard.auth.AuthValueFactoryProvider;
 import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.Authorizer;
 import io.dropwizard.auth.CachingAuthenticator;
-import io.dropwizard.auth.basic.BasicAuthFactory;
+import io.dropwizard.auth.basic.BasicCredentialAuthFilter;
 import io.dropwizard.auth.basic.BasicCredentials;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import java.security.Principal;
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 /**
  * An API key bundle that allows you to configure a set of users/applications that are allowed to
- * access APIs of the application in the Dropwizard configuration file.
+ * access APIs of the application in the Dropwizard configuration file. The API key bundle is bound
+ * to an ApiKeyBundleConfiguration type and a Principal type. You can use the DefaultApiKeyBundle
+ * class if you use use a default Principal implementation and do not require authorization.
  */
-@SuppressWarnings("UnusedDeclaration")
-public class ApiKeyBundle<T extends ApiKeyBundleConfiguration> implements ConfiguredBundle<T> {
+public class ApiKeyBundle<T extends ApiKeyBundleConfiguration, P extends Principal>
+    implements ConfiguredBundle<T> {
+  private final Class<P> principalClass;
+  private final PrincipalFactory<P> factory;
+  private final Authorizer<P> authorizer;
+
+  /**
+   * Construct the ApiKeyBundle using the provided Principal class, PrincipalFactory and
+   * Authorizer.
+   *
+   * @param principalClass The class of the class extending the Principal type.
+   * @param factory The PrincipalFactory instance, which can create new P objects.
+   * @param authorizer The Authorizer instance, which can create new P objects.
+   */
+  public ApiKeyBundle(Class<P> principalClass, PrincipalFactory<P> factory,
+      Authorizer<P> authorizer) {
+    this.principalClass = checkNotNull(principalClass);
+    this.factory = checkNotNull(factory);
+    this.authorizer = checkNotNull(authorizer);
+  }
+
   @Override
   public void initialize(Bootstrap<?> bootstrap) {
   }
@@ -32,25 +57,33 @@ public class ApiKeyBundle<T extends ApiKeyBundleConfiguration> implements Config
     Optional<AuthConfiguration> basic = configuration.getBasicConfiguration();
     checkState(basic.isPresent(), "A basic-http configuration option must be specified");
 
-    AuthFactory<?, String> factory = createBasicAuthFactory(basic.get(), environment.metrics());
-    environment.jersey().register(AuthFactory.binder(factory));
+    environment.jersey().register(new AuthDynamicFeature(
+        createBasicCredentialAuthFilter(basic.get(), environment.metrics())));
+    environment.jersey().register(new AuthValueFactoryProvider.Binder<>(principalClass));
   }
 
-  private BasicAuthFactory<String> createBasicAuthFactory(AuthConfiguration config,
-                                                          MetricRegistry metrics) {
-    Authenticator<BasicCredentials, String> authenticator = createAuthenticator(config);
+  private BasicCredentialAuthFilter<P> createBasicCredentialAuthFilter(AuthConfiguration config,
+      MetricRegistry metrics) {
+    final BasicCredentialAuthFilter<P> authFilter =
+        new BasicCredentialAuthFilter.Builder<P>()
+            .setAuthenticator(createAuthenticator(config, metrics))
+            .setRealm(config.getRealm())
+            .setAuthorizer(authorizer)
+            .buildAuthFilter();
+    return authFilter;
+  }
+
+  private Authenticator<BasicCredentials, P> createAuthenticator(AuthConfiguration config,
+      MetricRegistry metrics) {
+    Map<String, ApiKey> keys = config.getApiKeys();
+    Authenticator<BasicCredentials, P> authenticator =
+        new BasicCredentialsAuthenticator<>(keys::get, factory);
 
     Optional<String> cacheSpec = config.getCacheSpec();
     if (cacheSpec.isPresent()) {
       CacheBuilderSpec spec = CacheBuilderSpec.parse(cacheSpec.get());
       authenticator = new CachingAuthenticator<>(metrics, authenticator, spec);
     }
-
-    return new BasicAuthFactory<>(authenticator, config.getRealm(), String.class);
-  }
-
-  private Authenticator<BasicCredentials, String> createAuthenticator(AuthConfiguration config) {
-    Map<String, ApiKey> keys = config.getApiKeys();
-    return new BasicCredentialsAuthenticator(keys::get);
+    return authenticator;
   }
 }

--- a/src/main/java/io/dropwizard/bundles/apikey/BasicCredentialsAuthenticator.java
+++ b/src/main/java/io/dropwizard/bundles/apikey/BasicCredentialsAuthenticator.java
@@ -4,21 +4,25 @@ import com.google.common.base.Optional;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.basic.BasicCredentials;
+import java.security.Principal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * An Authenticator that converts HTTP basic authentication credentials into an API key.
  */
-public class BasicCredentialsAuthenticator implements Authenticator<BasicCredentials, String> {
+public class BasicCredentialsAuthenticator<P extends Principal>
+    implements Authenticator<BasicCredentials, P> {
   private final ApiKeyProvider provider;
+  private final PrincipalFactory<P> factory;
 
-  BasicCredentialsAuthenticator(ApiKeyProvider provider) {
+  BasicCredentialsAuthenticator(ApiKeyProvider provider, PrincipalFactory<P> factory) {
     this.provider = checkNotNull(provider);
+    this.factory = checkNotNull(factory);
   }
 
   @Override
-  public Optional<String> authenticate(BasicCredentials credentials)
+  public Optional<P> authenticate(BasicCredentials credentials)
       throws AuthenticationException {
     checkNotNull(credentials);
 
@@ -34,6 +38,6 @@ public class BasicCredentialsAuthenticator implements Authenticator<BasicCredent
       return Optional.absent();
     }
 
-    return Optional.of(key.getUsername());
+    return Optional.of(factory.create(key.getUsername()));
   }
 }

--- a/src/main/java/io/dropwizard/bundles/apikey/DefaultApiKeyBundle.java
+++ b/src/main/java/io/dropwizard/bundles/apikey/DefaultApiKeyBundle.java
@@ -1,0 +1,16 @@
+package io.dropwizard.bundles.apikey;
+
+import io.dropwizard.auth.PermitAllAuthorizer;
+import java.security.Principal;
+
+/**
+ * The DefaultApiKeyBundle class provides the base implementation of the API key-based
+ * authentication, providing a simple Principal implementation and no authorization logic (permit
+ * all).
+ */
+public class DefaultApiKeyBundle<T extends ApiKeyBundleConfiguration>
+    extends ApiKeyBundle<T, Principal> {
+  public DefaultApiKeyBundle() {
+    super(Principal.class, new DefaultPrincipalFactory(), new PermitAllAuthorizer<>());
+  }
+}

--- a/src/main/java/io/dropwizard/bundles/apikey/DefaultPrincipalFactory.java
+++ b/src/main/java/io/dropwizard/bundles/apikey/DefaultPrincipalFactory.java
@@ -1,0 +1,15 @@
+package io.dropwizard.bundles.apikey;
+
+import io.dropwizard.auth.PrincipalImpl;
+import java.security.Principal;
+
+/**
+ * A PrincipalFactory that provides a simple implementation of a Principal provided
+ * by the Dropwizard Auth module.
+ */
+public class DefaultPrincipalFactory implements PrincipalFactory<Principal> {
+  @Override
+  public Principal create(String name) {
+    return new PrincipalImpl(name);
+  }
+}

--- a/src/main/java/io/dropwizard/bundles/apikey/PrincipalFactory.java
+++ b/src/main/java/io/dropwizard/bundles/apikey/PrincipalFactory.java
@@ -1,0 +1,15 @@
+package io.dropwizard.bundles.apikey;
+
+import java.security.Principal;
+
+/**
+ * An interface for classes which create principal objects.
+ *
+ * @param <P> the type of principal
+ */
+public interface PrincipalFactory<P extends Principal> {
+  /**
+   * Create an instance of P from the specified name.
+   */
+  P create(String name);
+}

--- a/src/test/java/io/dropwizard/bundles/apikey/BasicCredentialsAuthenticatorTest.java
+++ b/src/test/java/io/dropwizard/bundles/apikey/BasicCredentialsAuthenticatorTest.java
@@ -3,6 +3,7 @@ package io.dropwizard.bundles.apikey;
 import com.google.common.base.Optional;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.basic.BasicCredentials;
+import java.security.Principal;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -13,11 +14,17 @@ import static org.mockito.Mockito.when;
 
 public class BasicCredentialsAuthenticatorTest {
   private final ApiKeyProvider provider = mock(ApiKeyProvider.class);
-  private final BasicCredentialsAuthenticator auth = new BasicCredentialsAuthenticator(provider);
+  private final BasicCredentialsAuthenticator<Principal> auth =
+      new BasicCredentialsAuthenticator<>(provider, new DefaultPrincipalFactory());
 
   @Test(expected = NullPointerException.class)
   public void testNullProvider() {
-    new BasicCredentialsAuthenticator(null);
+    new BasicCredentialsAuthenticator<Principal>(null, new DefaultPrincipalFactory());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullFactory() {
+    new BasicCredentialsAuthenticator<Principal>(provider, null);
   }
 
   @Test
@@ -26,9 +33,9 @@ public class BasicCredentialsAuthenticatorTest {
     when(provider.get("username")).thenReturn(key);
 
     BasicCredentials credentials = new BasicCredentials("username", "secret");
-    Optional<String> actual = auth.authenticate(credentials);
+    Optional<Principal> actual = auth.authenticate(credentials);
     assertTrue(actual.isPresent());
-    assertEquals("username", actual.get());
+    assertEquals("username", actual.get().getName());
   }
 
   @Test
@@ -37,7 +44,7 @@ public class BasicCredentialsAuthenticatorTest {
     when(provider.get("username")).thenReturn(key);
 
     BasicCredentials credentials = new BasicCredentials("username", "secret");
-    Optional<String> actual = auth.authenticate(credentials);
+    Optional<Principal> actual = auth.authenticate(credentials);
     assertFalse(actual.isPresent());
   }
 
@@ -46,7 +53,7 @@ public class BasicCredentialsAuthenticatorTest {
     when(provider.get("username")).thenReturn(null);
 
     BasicCredentials credentials = new BasicCredentials("username", "secret");
-    Optional<String> actual = auth.authenticate(credentials);
+    Optional<Principal> actual = auth.authenticate(credentials);
     assertFalse(actual.isPresent());
   }
 


### PR DESCRIPTION
…solve around the use of the Principal interface and optionally providing support for authorization through an Authorizer.

The simplest (and likely most common) use of the API bundle, and closest to the version targeting Dropwizard 0.8, is to use the DefaultApiKeyBundle which uses the default implementation of the Principal interface (provided by the Dropwizard Auth module) and a permit all authorization scheme. You do need to annotate your resource with a Principal type instead of a String, however given the Principal interface is provided through a base package (java.security) this will meets the desire to avoid using interfaces/classes from the library in the resources (one of the reason ApiKey was refactored to a String in an earlier release).

However if you require the use of a different Principal implementation, or an extending type, you can use the ApiKeyBundle directly and provide the Principal type and a PrincipalFactory. You can also provide an Authorizer if needed.

The migration changes are fully documented here: https://github.com/dropwizard/dropwizard/wiki/Upgrade-guide-0.8.x-to-0.9.x.
